### PR TITLE
Remove trailing slashes and update redirected Ultralytics URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,7 +70,7 @@ body:
     attributes:
       label: Minimal Reproducible Example
       description: >
-        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example/).
+        When asking a question, people will be better able to provide help if you provide code that they can easily understand and use to **reproduce** the problem. This is referred to by community members as creating a [minimal reproducible example](https://docs.ultralytics.com/help/minimum-reproducible-example).
       placeholder: |
         ```matlab
         % Code to reproduce your issue here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,5 +12,5 @@ contact_links:
     url: https://ultralytics.com/discord
     about: Ask on Ultralytics Discord
   - name: ⌨️ Reddit
-    url: https://reddit.com/r/ultralytics
+    url: https://www.reddit.com/r/Ultralytics/
     about: Ask on Ultralytics Subreddit

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,7 +6,7 @@ contact_links:
     url: https://github.com/ultralytics/ntc#readme
     about: Repository overview and usage
   - name: 💬 Forum
-    url: https://community.ultralytics.com/
+    url: https://community.ultralytics.com
     about: Ask on Ultralytics Community Forum
   - name: 🎧 Discord
     url: https://ultralytics.com/discord

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://www.ultralytics.com/"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
+<a href="https://www.ultralytics.com"><img src="https://raw.githubusercontent.com/ultralytics/assets/main/logo/Ultralytics_Logotype_Original.svg" width="320" alt="Ultralytics logo"></a>
 
 # 🌟 Neutron TimeCube (NTC)
 
@@ -6,8 +6,8 @@ Welcome to the Neutron TimeCube (NTC) analysis tools repository! This project pr
 
 [![Ultralytics Actions](https://github.com/ultralytics/ntc/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/ntc/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
-[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com/)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://reddit.com/r/ultralytics)
+[![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
 
 ## 📜 Project Overview
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to the Neutron TimeCube (NTC) analysis tools repository! This project pr
 [![Ultralytics Actions](https://github.com/ultralytics/ntc/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/ntc/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
 [![Ultralytics Forums](https://img.shields.io/discourse/users?server=https%3A%2F%2Fcommunity.ultralytics.com&logo=discourse&label=Forums&color=blue)](https://community.ultralytics.com)
-[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/ultralytics/)
+[![Ultralytics Reddit](https://img.shields.io/reddit/subreddit-subscribers/ultralytics?style=flat&logo=reddit&logoColor=white&label=Reddit&color=blue)](https://www.reddit.com/r/Ultralytics/)
 
 ## 📜 Project Overview
 


### PR DESCRIPTION
## Summary
- removed trailing slashes from 4 Ultralytics URL instances across 3 source files
- refreshed 2 redirected Reddit links to the final canonical HTTPS URL

## Judgment
- rejected redirects: none
- dead links: none

## Validation
- manually reviewed every changed URL in context
- trailing-slash rescan: 0 eligible URLs
- redirect rescan: 0 proposals
- verified Reddit canonical casing directly before addressing automated review
- YAML parse and git diff checks passed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated Ultralytics links across issue templates and `README.md` to remove unnecessary trailing slashes and use Reddit’s canonical HTTPS URL.

### 📊 Key Changes

- Removed trailing slashes from the minimum reproducible example, community forum, and Ultralytics homepage links.
- Updated Reddit links from `https://reddit.com/r/ultralytics` to `https://www.reddit.com/r/Ultralytics/`.
- Applied the URL updates in `.github/ISSUE_TEMPLATE/bug-report.yml`, `.github/ISSUE_TEMPLATE/config.yml`, and `README.md`.

### 🎯 Purpose & Impact

- Links now use consistent URL formatting and the canonical Reddit address.
- No user-facing change beyond the destination URLs being standardized.